### PR TITLE
chore(ci): added Claude Code workflows

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -1,0 +1,15 @@
+name: 'Claude Code Review'
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    uses: 'rios0rios0/.github/.github/workflows/claude-code-review.yaml@main'
+    secrets: inherit
+    permissions:
+      contents: 'read'
+      pull-requests: 'write'
+      issues: 'write'
+      id-token: 'write'

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -1,0 +1,22 @@
+name: 'Claude Code'
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    uses: 'rios0rios0/.github/.github/workflows/claude.yaml@main'
+    secrets: inherit
+    permissions:
+      contents: 'write'
+      pull-requests: 'write'
+      issues: 'write'
+      id-token: 'write'
+      actions: 'read'


### PR DESCRIPTION
## Summary
- added `claude-code-review.yaml` for automated PR reviews via Claude Code
- added `claude.yaml` for interactive Claude Code assistant via `@claude` mentions

Both workflows delegate to the reusable workflows in `rios0rios0/.github`.

## Test plan
- [ ] verify workflows appear in the Actions tab
- [ ] confirm `CLAUDE_CODE_OAUTH_TOKEN` secret is configured