### PR TITLE
chore(ci): added release.yaml so chore/bump merges create tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,13 @@
+name: 'release'
+
+on:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  contents: 'write'
+
+jobs:
+  release:
+    uses: 'rios0rios0/pipelines/.github/workflows/release.yaml@main'


### PR DESCRIPTION
## Summary

Added `.github/workflows/release.yaml` calling the new reusable `rios0rios0/pipelines/.github/workflows/release.yaml@main` workflow. It fires only on pushes to `main` whose head commit message contains `chore/bump-`, and creates a Git tag + GitHub Release for the bumped version.

## Why

This repo had no pipeline at all, so every `chore/bump-X.Y.Z` PR merged by `autobump-automation` was landing in `main` without producing a tag. The new `release.yaml` reusable workflow ([promoted to dual-mode in PR #387](https://github.com/rios0rios0/pipelines/pull/387)) gives non-language repos (TeX, dotfiles, docs, configs, etc.) a tag-on-bump trigger without forcing a Docker build or a language-specific pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
