### PR TITLE
fix(chlog): restored the fragment directory with a placeholder

### DIFF
--- a/.changes/unreleased/1787775142194175612-4924.yaml
+++ b/.changes/unreleased/1787775142194175612-4924.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'restored the `.changes/unreleased/` directory with a `.gitkeep`, so the release tooling keeps recognising this project as [chlog](https://github.com/luizjhonata/chlog)-based after a release consumes the last fragment. Git tracks files rather than directories, so the bump commit that removed the final fragment removed the directory too, and the next run read the empty `[Unreleased]` section as "nothing to release"'
+time: '2026-08-26T20:12:22.194092477Z'


### PR DESCRIPTION
## Problem

Git tracks files, not directories. The last release consumed every pending [chlog](https://github.com/luizjhonata/chlog) fragment, so the `chore(bump)` commit that deleted them also removed `.changes/unreleased/` from the tree.

Both AutoBump's `DetectChlog` and the pipeline's `changelog-check.sh` recognise a chlog project by a `.chlog.yaml` **or** the `.changes/unreleased/` directory. With neither present, this repository stopped looking like a chlog user: the next AutoBump run would read its permanently empty `[Unreleased]` section as "nothing to release", and CI would start demanding a hand-edited `CHANGELOG.md` instead of a fragment.

## Fix

Adds `.changes/unreleased/.gitkeep` so the directory stays tracked when it holds no fragments.

AutoBump now writes this placeholder itself on every release ([rios0rios0/autobump#328](https://github.com/rios0rios0/autobump/pull/328)), so this will not recur — this PR repairs the repositories a release had already emptied.

The accompanying fragment is the changelog entry for this change; `.gitkeep` alone does not count as one for `changelog-check.sh`, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
